### PR TITLE
Using the ruby:2.3 image instead of ruby:2.3-onbuild

### DIFF
--- a/misc/beez-fight/challenge/Dockerfile
+++ b/misc/beez-fight/challenge/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-onbuild
+FROM ruby:2.3
 
 RUN apt-get update && apt-get install -y xinetd
 RUN adduser --disabled-password --gecos '' ctf


### PR DESCRIPTION
I believe this is the fix we need for #1. Since there is no Gemfile, no need to use the onbuild image.